### PR TITLE
Pass-through unrecognized custom priority levels

### DIFF
--- a/bin/jilla
+++ b/bin/jilla
@@ -218,6 +218,7 @@ function formatPrio(name) {
   if (name == 'Major')    return '!!';
   if (name == 'Critical') return '!!!';
   if (name == 'Blocker')  return '!!!!';
+  return name;
 }
 
 function load(cb) {


### PR DESCRIPTION
With custom priority levels formatPrio() returned 'undefined', which
then broke formatTable() when trying to compute the cell size.

Simply return the original value if not known.
