### PR TITLE
Added new method status (add/change the status of an issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Commands:
    resolve   <id>              Resolve issue
    reopen    <id>              Reopen issue
    close     <id>              Close issue
+   needinfo  <id>              Set issue status to Needs Info
+   status    <id> (status)     Changes issue status to "status" (no status to get a list of options)
    search    <term>            Find issues
    describe  <id>              Display issue synopsis
    comments  <id> (--reverse)  Display comments on an issue
@@ -97,6 +99,20 @@ WDSERVICE-79 <fstock>   ! LessLinter testen
 $ jilla resolve PS-656
 $ jilla close PS-656
 $ jilla reopen PS-656
+```
+
+### Change status of an issue
+
+```bash
+$ jilla status PS-656
+Current Status : 6 Closed
+Statuses available :
+21 Reopen
+$ jilla status PS-656 21
+$ jilla status PS-656
+Current Status : 1 Open
+Statuses available :
+31 Start Progress
 ```
 
 ### Describe an issue

--- a/bin/jilla
+++ b/bin/jilla
@@ -40,18 +40,86 @@ load(function(_cfg, _db) {
   if (cmd == 'comment')   return comment(process.argv[3], process.argv.slice(4));
   if (cmd == 'user')      return user(process.argv.slice(3));
   if (cmd == 'assign')    return assign(process.argv[3], process.argv.slice(4));
+  if (cmd == 'status')    return setStatus(undefined, new Array (process.argv[3], process.argv[4]));
   usage();
 });
 
 function proxyIfNeeded(request) {
-  if (proxy != undefined && proxy != ""){
-    return request.proxy (proxy);
+  if (proxy != undefined && proxy != "") {
+    return request.proxy(proxy);
   }
   return request;
 }
 
 function config() {
   configBasicAuth();
+}
+
+function statusesObject (func, issue, args) {
+  proxyIfNeeded(request
+    .get(cfg.url + 'rest/api/2/' + (issue == undefined ? 'status': 'issue/' + issue + '/transitions'))
+    )
+    .set('Content-Type', 'application/json')
+    .auth(cfg.user, cfg.password)
+    .end(function(res) {
+      if (res.body.transitions) {
+        return func(res.body.transitions, args);
+      }
+      return func(res.body, args);
+    });
+}
+
+function currentStatus (issueKey, func) {
+   proxyIfNeeded (request
+    .get(cfg.url + 'rest/api/2/issue/' + issueKey)
+    )
+    .set('Content-Type', 'application/json')
+    .auth(cfg.user, cfg.password)
+    .end(function(res) {
+      if (res.body.errorMessages) {
+        console.log(res.body.errorMessages.join ('\n'));
+        return;
+      }
+     var formatted = [];
+     formatted.push([res.body.fields.status.id,
+            res.body.fields.status.name]);
+     func(formatTable(formatted));
+    });
+}
+
+function setStatus (obj, args) {
+  if (args[0] == undefined) {
+    console.log("Please provide an issue ID");
+    return;
+  }
+  if (obj == undefined) {
+    statusesObject(setStatus, args[0], args);
+  } else {
+    var newStatus = -1;
+    for (var index in obj) {
+      if ((obj[index].name == args[1] ||
+          obj[index].id == args[1]) &&
+          obj[index].id != undefined) {
+        newStatus = obj[index].id;
+      }
+    }
+    if (newStatus == -1) {
+      currentStatus(args[0], function (currStatus) {
+        console.log("Current Status : " + currStatus);
+        console.log("Statuses available :");
+        for (var iRow in obj) {
+          var row = obj[iRow];
+          var formatted = [];
+          formatted.push(
+            [row.id,
+             row.name]);
+          console.log(formatTable(formatted));
+        }
+      });
+    } else {
+      transition(args[0], newStatus);
+    }
+  }
 }
 
 function ls() {
@@ -323,6 +391,7 @@ function usage() {
   console.log('   reopen    <id>              Reopen issue');
   console.log('   close     <id>              Close issue');
   console.log('   needinfo  <id>              Set issue status to Needs Info');
+  console.log('   status    <id> (status)     Changes issue status to "status" (no status to get a list of options)');
   console.log('   search    <term>            Find issues');
   console.log('   describe  <id>              Display issue synopsis');
   console.log('   comments  <id> (--reverse)  Display comments on an issue');


### PR DESCRIPTION
Here is a new method to provide a different way to change the status of an issue. It is possible to see which transition is possible and what is the current state of an issue. And with an adequate transition, an issue can be moved to another status
